### PR TITLE
update cliffy

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,4 @@
-import { parseFlags } from "https://deno.land/x/cliffy@v0.18.0/flags/mod.ts";
-import { existsSync } from "https://deno.land/std@0.89.0/fs/mod.ts";
+import { existsSync, parseFlags } from "./deps.ts";
 import {
   CommandRunner,
   filterScripts,

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { Select } from "https://deno.land/x/cliffy@v0.18.0/prompt/mod.ts";
+import { Select } from "./deps.ts";
 
 type Scripts = {
   [key: string]: string;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,0 +1,3 @@
+export { Select } from "https://deno.land/x/cliffy@v0.18.2/prompt/mod.ts";
+export { parseFlags } from "https://deno.land/x/cliffy@v0.18.2/flags/mod.ts";
+export { existsSync } from "https://deno.land/std@0.89.0/fs/mod.ts";

--- a/test/command_test.ts
+++ b/test/command_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.89.0/testing/asserts.ts";
+import { assertEquals } from "./deps.ts";
 import { parseArguments } from "../src/command.ts";
 
 Deno.test("parseArguments", () => {

--- a/test/core_test.ts
+++ b/test/core_test.ts
@@ -1,5 +1,4 @@
-import { dirname, fromFileUrl } from "https://deno.land/std@0.89.0/path/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.89.0/testing/asserts.ts";
+import { assertEquals, dirname, fromFileUrl } from "./deps.ts";
 import {
   CommandRunner,
   filterScripts,

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,0 +1,2 @@
+export { assertEquals } from "https://deno.land/std@0.89.0/testing/asserts.ts";
+export { dirname, fromFileUrl } from "https://deno.land/std@0.89.0/path/mod.ts";


### PR DESCRIPTION
Update cliffy to 0.18.2 which fixes an error (at least in deno 1.9.2)

Before the update nps would fail with
```
error: TS2729 [ERROR]: Property 'prompts' is used before its initialization.
  private names: string[] = this.prompts.map((prompt) => prompt.name);
                                 ~~~~~~~
    at https://deno.land/x/cliffy@v0.18.0/prompt/prompt.ts:2011:34

    'prompts' is declared here.
        private prompts: PromptOptions<string, any, any>[],
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        at https://deno.land/x/cliffy@v0.18.0/prompt/prompt.ts:2019:5
```

Now it succeeds and all tests pass.
I also moved all the external dependencies into `deps.ts` files so that  bumping versions would be easier to track.